### PR TITLE
Fix Mathjax in prod (use https) and upgrade it from 2 to 3

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -43,8 +43,8 @@
     {% if page.usemathjax %}
     <script>
       MathJax = {
-        tex: {tags: 'ams', inlineMath: [['$', '$'], ['\\(', '\\)']]},
-        tex: { 
+        tex: {
+          inlineMath: [['$', '$'], ['\\(', '\\)']],
           tags: 'ams'
         },
         svg: {

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,11 +1,11 @@
 <html>
   <head>
-    <script src="{{ 'assets/js/store.js?v=1.1' | relative_url }}" type="text/javascript"></script>
     <script src="{{ '/assets/js/config.js?v=1.1' | relative_url }}" type="text/javascript"></script>
     <script src="{{ '/assets/js/index.js?v=1.1' | relative_url }}" type="text/javascript"></script>
 
     <script src="{{ '/components/project.js?v=1.1' | relative_url }}" type="text/javascript"></script>
     <script src="{{ '/components/statistic.js?v=1.1' | relative_url }}" type="text/javascript"></script>
+    <script src="{{ '/assets/js/store.js?v=1.1' | relative_url }}"></script>
 
     <meta name="viewport" content="width=device-width" />
     <link href="https://cdn.jsdelivr.net/npm/dress-code@2.4.0/dist/css/dress-code.min.css" rel="stylesheet">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,30 +1,33 @@
 <html>
   <head>
-    <script src="{{ '/assets/js/config.js?v=1.1' | relative_url }}" type="text/javascript"></script>
-    <script src="{{ '/assets/js/index.js?v=1.1' | relative_url }}" type="text/javascript"></script>
-
-    <script src="{{ '/components/project.js?v=1.1' | relative_url }}" type="text/javascript"></script>
-    <script src="{{ '/components/statistic.js?v=1.1' | relative_url }}" type="text/javascript"></script>
     <script src="{{ '/assets/js/store.js?v=1.1' | relative_url }}"></script>
+    <script src="{{ '/assets/js/config.js?v=1.1' | relative_url }}"></script>
+    <script src="{{ '/assets/js/index.js?v=1.1' | relative_url }}"></script>
+    <script src="{{ '/components/project.js?v=1.1' | relative_url }}"></script>
+    <script src="{{ '/components/statistic.js?v=1.1' | relative_url }}"></script>
 
-    <meta name="viewport" content="width=device-width" />
-    <link href="https://cdn.jsdelivr.net/npm/dress-code@2.4.0/dist/css/dress-code.min.css" rel="stylesheet">
     <link rel="shortcut icon" type="image/x-icon" href="{{ '/assets/img/mns.ico' | relative_url }}">
+    <link href="https://cdn.jsdelivr.net/npm/dress-code@2.4.0/dist/css/dress-code.min.css" rel="stylesheet">
     <link href="{{ '/assets/css/main.css' | relative_url }}" rel="stylesheet">
     <link href="{{ '/assets/css/article.css' | relative_url }}" rel="stylesheet">
     <link href="{{ '/assets/css/syntax.css' | relative_url }}" rel="stylesheet"/>
+    
+    <meta name="viewport" content="width=device-width" />
     <meta property="og:url" content="{{site.url}}{{page.url}}" />
     <meta property="og:type" content="website" />
+
     {% if page.title %}
     <meta property="og:title" content="{{site.title}} | {{page.title}}" />
     {% else %}
     <meta property="og:title" content="{{site.title}}" />
     {% endif %}
+
     {% if page.description %}
     <meta property="og:description" content="{{page.description}}" />
     {% else %}
     <meta property="og:description" content="{{site.description}}" />
     {% endif %}
+
     {% if page.banner.image %}
     <meta property="og:image" content="{{site.url}}/assets/img/{{page.banner.image}}" />
     {% else %}
@@ -38,14 +41,19 @@
     {% endif %}
 
     {% if page.usemathjax %}
-    <script type="text/x-mathjax-config">
-      MathJax.Hub.Config({
-      TeX: { equationNumbers: { autoNumber: "AMS" } }
-      });
+    <script>
+      MathJax = {
+        tex: {tags: 'ams', inlineMath: [['$', '$'], ['\\(', '\\)']]},
+        tex: { 
+          tags: 'ams'
+        },
+        svg: {
+          fontCache: 'global'
+        }
+      };
     </script>
-    <script type="text/javascript" async src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
-  {% endif %}
-  
+    <script async id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js"></script>
+    {% endif %}
   </head>
   <body>
     {% include header.html title=page.title %}

--- a/_posts/2022-07-08-sla-calculations.md
+++ b/_posts/2022-07-08-sla-calculations.md
@@ -64,7 +64,16 @@ There by the probability of unavailability is 0 for the mutually exclusive event
 
 > For the Mutually exclusive events , then probability of either occuring
 
-$$P(AR1 \space or \space AR2) = P(AR1 \space ∪ \space AR2 ) = (P(AR1) \space +  \space P(AR2) - P(AR1 ∩ AR2) = P(AR1) \space + \space  P(AR2) \space - \space 0 \space =  P(AR1) \space + \space  P(AR2)$$
+<p>
+\begin{equation}
+\begin{split}
+P(AR1 \space OR \space AR2) & = P(AR1 ∪ AR2) \\
+              & = (P(AR1) + P(AR2) - P(AR1 ∩ AR2) \\
+              & = P(AR1) + P(AR2) - 0 \\
+              & = P(AR1) + P(AR2)
+\end{split}
+\end{equation}
+</p>
 
 calculating that as values
 - Probability of AR1 to be down : 0.0005


### PR DESCRIPTION
## Changes

1. Use `https` for Mathjax script to fix browser prod grievance
2. Upgrade Mathjax from 2 to 3 because it's shiny and loads marginally faster
3. Change one equation to use split syntax because it was going beyond the end of the page and Mathjax doesn't have automatic line breaking

## Known issues

1. There are other long equations; I've only changed one of them
2. Automatic equation numbering has now started working too but only for the equation that's been written with `\begin\end` syntax

## How to test (macOS)

Check out this branch then:

```sh
# Need webrick locally because using Jekyll < 4
bundle add webrick
bundle install
bundle exec jekyll serve
open http://localhost:4000

# Browse and check...

# Don't commit webrick
git reset --hard
```